### PR TITLE
reference proper location of files for bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -8,7 +8,7 @@
     "Telerik"
   ],
   "description": "Everything you need to build sites and apps with HTML5 & JavaScript",
-  "main": "dist/kendo.ui.core.min.js",
+  "main": "js/kendo.ui.core.min.js",
   "moduleType": [
     "amd",
     "globals"


### PR DESCRIPTION
There is no dist folder, so pointed to js.

Would address Issue #13

Also need to bump version number so bower picks up the change.
